### PR TITLE
LoanScan-Uniswap API integrated

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -147,7 +147,7 @@ class App extends Component {
     if (directory.length === 0)
       return (
         <Wrapper>
-          <Loader fill={true} />
+          <Loader fill="true" />
         </Wrapper>
       );
 

--- a/src/containers/chartContainer.js
+++ b/src/containers/chartContainer.js
@@ -27,7 +27,7 @@ export class ChartContainer extends Container {
           utcStartTime = utcEndTime.subtract(1, "year").startOf("year");
           unit = "month";
           break;
-        case "3month":
+        case "3months":
           utcStartTime = utcEndTime.subtract(3, "month").startOf("month");
           unit = "day";
           break;

--- a/src/containers/directoryContainer.js
+++ b/src/containers/directoryContainer.js
@@ -24,16 +24,16 @@ export class DirectoryContainer extends Container {
       const json = await data.json();
 
       let directoryObjects = {};
-      json.forEach(exchange => {
+      json.exchanges.forEach(exchange => {
         directoryObjects[exchange.exchangeAddress] = buildDirectoryObject(
           exchange
         );
       });
 
-      console.log(`fetched ${json.length} exchanges`);
+      console.log(`fetched ${json.exchanges.length} exchanges`);
 
       await this.setState({
-        directory: json.map(exchange => buildDirectoryLabel(exchange)),
+        directory: json.exchanges.map(exchange => buildDirectoryLabel(exchange)),
         exchanges: directoryObjects
       });
 
@@ -90,10 +90,7 @@ export class DirectoryContainer extends Container {
             percentChange,
             tradeVolume: Big(tradeVolume).toFixed(4),
             ethLiquidity: Big(ethLiquidity).toFixed(4),
-            erc20Liquidity: (
-              erc20Liquidity /
-              Math.pow(10, this.state.exchanges[address].tokenDecimals)
-            ).toFixed(4)
+            erc20Liquidity: Big(erc20Liquidity).toFixed(4)
           }
         }
       }));

--- a/src/containers/transactionsContainer.js
+++ b/src/containers/transactionsContainer.js
@@ -15,8 +15,30 @@ export class TransactionsContainer extends Container {
       // current time
       const utcEndTime = dayjs();
 
+      let utcStartTime;
+
       // go back n days
-      const utcStartTime = utcEndTime.subtract(daysToQuery, "day");
+      switch (daysToQuery) {
+        case "1week":
+          utcStartTime = utcEndTime.subtract(7, "day");
+          break;
+      
+        case "1month":
+          utcStartTime = utcEndTime.subtract(1, "month");
+          break;
+
+        case "3months":
+          utcStartTime = utcEndTime.subtract(3, "month");
+          break;
+        
+        case "all":
+          utcStartTime = utcEndTime.subtract(1, "year");
+          break;
+          
+        default:
+          utcStartTime = utcEndTime.subtract(7, "day");
+          break;
+      }
 
       const data = await fetch(
         `${BASE_URL}v1/history?exchangeAddress=${exchangeAddress}&startTime=${utcStartTime.unix()}&endTime=${utcEndTime.unix()}`

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -4,10 +4,10 @@ import Uniswap from "../constants/Uniswap";
 
 BigNumber.set({ EXPONENTIAL_AT: 50 });
 
-export const BASE_URL = "https://uniswap-analytics.appspot.com/api/";
+export const BASE_URL = "https://uniswap-api-staging.loanscan.io/";
 
 export const tokenOptions = Object.keys(Uniswap.tokens).map(key => ({
-  value: `${Uniswap.tokens[key].address}`,
+  value: `${Uniswap.tokens[key].address}`,  
   // label: `${key} - ${Uniswap.tokens[key].address}`
   label: key
 }));
@@ -51,7 +51,7 @@ export const toK = (num, fixed) => {
 export const setThemeColor = theme =>
   document.documentElement.style.setProperty("--c-token", theme || "#333333");
 
-export const Big = number => new BigNumber(number).dividedBy(1e18);
+export const Big = number => new BigNumber(number);
 
 export const urls = {
   showTransaction: tx => `https://etherscan.io/tx/${tx}/`,


### PR DESCRIPTION
The main aim of this PR is to integrate [LoanScan-Uniswap-API](https://github.com/loanscan/uniswap-statistics-api) to [Uniswap-info](http://beta.uniswap.info/) application.
List of changes:
- chartContainer.js: "3month" --> “3months”;
- directoryContainer.js: use `json.exchanges` for refer to data from `/directory` end-point;
- directoryContainer.js: removed redundant division for `erc20Liquidity`;
- transactionContainer.js: added switch-case construction as in chartContainer.js to calc `utcStartTime` value properly;
- helpers/index.js: removed redundant division by 10e18 because all number values from API are floats;