### PR TITLE
WIP: Issue 37 fix pool share calc

### DIFF
--- a/src/containers/poolContainer.js
+++ b/src/containers/poolContainer.js
@@ -35,7 +35,8 @@ export class PoolContainer extends Container {
       console.log(`fetched ${userAccount}'s pool share for ${exchangeAddress}`)
 
       // NOTE: workaround for bug in uniswap-statistics-api
-      // uniswap-statistics-api returns numbers that are 10**10 times too big
+      // uniswap-statistics-api returns numbers that don't take into account
+      // tokens that have fewer than 18 decimal places
       // see: https://github.com/loanscan/uniswap-statistics-api/issues/7
       const tokenDecimals = exchangeJson.tokenDecimals
       const userNumPoolTokens = Big(userJson.userNumPoolTokens).dividedBy(10**(18 - tokenDecimals)).toFixed(4)

--- a/src/containers/poolContainer.js
+++ b/src/containers/poolContainer.js
@@ -26,9 +26,12 @@ export class PoolContainer extends Container {
 
       console.log(`fetched ${userAccount}'s pool share for ${exchangeAddress}`)
 
+      // NOTE: workaround for bug in uniswap-statistics-api
+      // uniswap-statistics-api returns numbers that are 10**10 times too big
+      // see: https://github.com/loanscan/uniswap-statistics-api/issues/7
       this.setState({
-        userNumPoolTokens: Big(json.userNumPoolTokens).toFixed(4),
-        userPoolPercent: (json.userPoolPercent * 100).toFixed(2)
+        userNumPoolTokens: Big(json.userNumPoolTokens).dividedBy(10**10).toFixed(4),
+        userPoolPercent: Big(json.userPoolPercent * 100).dividedBy(10**10).toFixed(2)
       })
     } catch (err) {
       console.log('error: ', err)


### PR DESCRIPTION
Currently, this is a workaround for the no-longer-maintained by loanscan stats http api (see comments in the linked issue).

You could probably pull in this fix and it would make users happier, but it isn't a great fix.

Tested locally/manually on mkr, wbtc, and usdc and it looks good. Props to the quick and easy yarn setup.

Thinking longer term however, I'm wondering if there's a reasonable way to get the pool share percentage without relying on the loanscan api.