### PR TITLE
Update trustwallet github logo repository

### DIFF
--- a/src/components/TokenLogo/index.js
+++ b/src/components/TokenLogo/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 
-const TOKEN_ICON_API = 'https://raw.githubusercontent.com/TrustWallet/tokens/master/tokens'
+const TOKEN_ICON_API = 'https://raw.githubusercontent.com/TrustWallet/assets/master/blockchains/ethereum/assets/'
 const BAD_IMAGES = {}
 
 const Inline = styled.div`
@@ -52,7 +52,7 @@ export default function TokenLogo({ address, header = false, size = '1rem', ...r
     address = '0xc011a72400e58ecd99ee497cf89e3775d4bd732f'
   }
 
-  const path = `${TOKEN_ICON_API}/${address.toLowerCase()}.png`
+  const path = `${TOKEN_ICON_API}/${address.toLowerCase()}/logo.png`
 
   return (
     <Inline>


### PR DESCRIPTION
The [TrustWallet/tokens](https://github.com/trustwallet/tokens) repository is deprecated and now the logos should be retrieved from [TrustWallet/assets](https://github.com/trustwallet/assets)

Old repo:
<img width="837" alt="Captura de pantalla 2019-11-06 a las 0 11 55" src="https://user-images.githubusercontent.com/12701942/68254163-2d7cc700-002a-11ea-9db6-7c0737ecae3b.png">

New repo:
<img width="850" alt="Captura de pantalla 2019-11-06 a las 0 15 01" src="https://user-images.githubusercontent.com/12701942/68254291-80ef1500-002a-11ea-9862-ff971ceb9bc3.png">
