### PR TITLE
Improve copy for empty TransactionsList

### DIFF
--- a/src/components/TransactionsList/index.js
+++ b/src/components/TransactionsList/index.js
@@ -100,7 +100,7 @@ const ClickableText = styled(Text)`
   &:hover {
     cursor: pointer;
     opacity: 0.6;
-  
+
   user-select: none;
 `
 
@@ -503,7 +503,10 @@ function TransactionsList({ tokenSymbol, exchangeAddress, price, priceUSD, txFil
       </DashGrid>
       <Divider />
       <List p={0}>
-        {!loading && txs && filteredTxs.length === 0 ? <EmptyTxWrapper>No transactions</EmptyTxWrapper> : ''}
+        {(!loading && txs && filteredTxs.length === 0)
+          ? <EmptyTxWrapper>No transactions in last 24 hours</EmptyTxWrapper>
+          : ''
+        }
         {loading ? (
           <LocalLoader />
         ) : (


### PR DESCRIPTION
**Old copy:** No transactions
**New copy:** No transactions in last 24 hours


Even though the TransactionList table header labels itself `Transactions (24h)`, I was at first glance confused when I noticed the new `uniswap.info` site appeared to be missing `$SOCKS` transaction data. https://uniswap.info/token/0x23b608675a2b2fb1890d3abbd85c5775c51691d5

This Pull Request updates the copy displayed in the `empty TransactionList` to make it more clear that the list is only surfacing transactions from the last 24 hours.

🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️🦄️