### PR TITLE
round timestamps to nearest minute to reduce load on hosted graph end…

### DIFF
--- a/src/contexts/GlobalData.js
+++ b/src/contexts/GlobalData.js
@@ -169,8 +169,14 @@ async function getGlobalData(ethPrice) {
   let twoDayData = {}
   try {
     const utcCurrentTime = dayjs()
-    const utcOneDayBack = utcCurrentTime.subtract(1, 'day').unix()
-    const utcTwoDaysBack = utcCurrentTime.subtract(2, 'day').unix()
+    const utcOneDayBack = utcCurrentTime
+      .subtract(1, 'day')
+      .startOf('minute')
+      .unix()
+    const utcTwoDaysBack = utcCurrentTime
+      .subtract(2, 'day')
+      .startOf('minute')
+      .unix()
     let oneDayBlock = await getBlockFromTimestamp(utcOneDayBack)
     let twoDayBlock = await getBlockFromTimestamp(utcTwoDaysBack)
 
@@ -374,7 +380,10 @@ const getGlobalTransactions = async () => {
 
 const getEthPrice = async () => {
   const utcCurrentTime = dayjs()
-  const utcOneDayBack = utcCurrentTime.subtract(1, 'day').unix()
+  const utcOneDayBack = utcCurrentTime
+    .subtract(1, 'day')
+    .startOf('minute')
+    .unix()
 
   let ethPrice = 0
   let ethPriceOneDay = 0
@@ -501,7 +510,7 @@ export function useGlobalChartData() {
         utcStartTime = utcEndTime.subtract(1, 'year').startOf('year')
         break
     }
-    let startTime = utcStartTime.unix() - 1
+    let startTime = utcStartTime.startOf('minute').unix() - 1
 
     if ((activeWindow && startTime < oldestDateFetch) || !oldestDateFetch) {
       setOldestDateFetched(startTime)

--- a/src/contexts/PairData.js
+++ b/src/contexts/PairData.js
@@ -138,9 +138,18 @@ export default function Provider({ children }) {
 
 async function getBulkPairData(pairList, ethPrice) {
   const utcCurrentTime = dayjs()
-  const utcOneDayBack = utcCurrentTime.subtract(1, 'day').unix()
-  const utcTwoDaysBack = utcCurrentTime.subtract(2, 'day').unix()
-  const utcOneWeekBack = utcCurrentTime.subtract(1, 'week').unix()
+  const utcOneDayBack = utcCurrentTime
+    .subtract(1, 'day')
+    .startOf('minute')
+    .unix()
+  const utcTwoDaysBack = utcCurrentTime
+    .subtract(2, 'day')
+    .startOf('minute')
+    .unix()
+  const utcOneWeekBack = utcCurrentTime
+    .subtract(1, 'week')
+    .startOf('minute')
+    .unix()
   let oneDayBlock = await getBlockFromTimestamp(utcOneDayBack)
   let twoDayBlock = await getBlockFromTimestamp(utcTwoDaysBack)
   let oneWeekBlock = await getBlockFromTimestamp(utcOneWeekBack)
@@ -243,9 +252,18 @@ async function getBulkPairData(pairList, ethPrice) {
 
 const getTopPairData = async ethPrice => {
   const utcCurrentTime = dayjs()
-  const utcOneDayBack = utcCurrentTime.subtract(1, 'day').unix()
-  const utcTwoDaysBack = utcCurrentTime.subtract(2, 'day').unix()
-  const utcOneWeekBack = utcCurrentTime.subtract(1, 'week').unix()
+  const utcOneDayBack = utcCurrentTime
+    .subtract(1, 'day')
+    .startOf('minute')
+    .unix()
+  const utcTwoDaysBack = utcCurrentTime
+    .subtract(2, 'day')
+    .startOf('minute')
+    .unix()
+  const utcOneWeekBack = utcCurrentTime
+    .subtract(1, 'week')
+    .startOf('minute')
+    .unix()
   let oneDayBlock = await getBlockFromTimestamp(utcOneDayBack)
   let twoDayBlock = await getBlockFromTimestamp(utcTwoDaysBack)
   let oneWeekBlock = await getBlockFromTimestamp(utcOneWeekBack)
@@ -370,9 +388,18 @@ const getPairData = async (address, ethPrice) => {
   let twoDayData = []
 
   const utcCurrentTime = dayjs()
-  const utcOneDayBack = utcCurrentTime.subtract(1, 'day').unix()
-  const utcTwoDaysBack = utcCurrentTime.subtract(2, 'day').unix()
-  const utcOneWeekBack = utcCurrentTime.subtract(1, 'week').unix()
+  const utcOneDayBack = utcCurrentTime
+    .subtract(1, 'day')
+    .startOf('minute')
+    .unix()
+  const utcTwoDaysBack = utcCurrentTime
+    .subtract(2, 'day')
+    .startOf('minute')
+    .unix()
+  const utcOneWeekBack = utcCurrentTime
+    .subtract(1, 'week')
+    .startOf('minute')
+    .unix()
   let oneDayBlock = await getBlockFromTimestamp(utcOneDayBack)
   let twoDayBlock = await getBlockFromTimestamp(utcTwoDaysBack)
   let oneWeekBlock = await getBlockFromTimestamp(utcOneWeekBack)
@@ -472,7 +499,7 @@ const getPairTransactions = async pairAddress => {
 const getPairChartData = async pairAddress => {
   let data = []
   const utcEndTime = dayjs.utc()
-  let utcStartTime = utcEndTime.subtract(1, 'year')
+  let utcStartTime = utcEndTime.subtract(1, 'year').startOf('minute')
   let startTime = utcStartTime.unix() - 1
 
   try {

--- a/src/contexts/TokenData.js
+++ b/src/contexts/TokenData.js
@@ -217,8 +217,14 @@ const getTopTokens = async (ethPrice, ethPriceOld) => {
 
 const getTokenData = async (address, ethPrice, ethPriceOld) => {
   const utcCurrentTime = dayjs()
-  const utcOneDayBack = utcCurrentTime.subtract(1, 'day').unix()
-  const utcTwoDaysBack = utcCurrentTime.subtract(2, 'day').unix()
+  const utcOneDayBack = utcCurrentTime
+    .subtract(1, 'day')
+    .startOf('minute')
+    .unix()
+  const utcTwoDaysBack = utcCurrentTime
+    .subtract(2, 'day')
+    .startOf('minute')
+    .unix()
   let oneDayBlock = await getBlockFromTimestamp(utcOneDayBack)
   let twoDayBlock = await getBlockFromTimestamp(utcTwoDaysBack)
 
@@ -313,7 +319,7 @@ const getTokenChartData = async tokenAddress => {
   let data = []
   const utcEndTime = dayjs.utc()
   let utcStartTime = utcEndTime.subtract(1, 'year')
-  let startTime = utcStartTime.unix() - 1
+  let startTime = utcStartTime.startOf('minute').unix() - 1
 
   try {
     let result = await client.query({
@@ -350,7 +356,7 @@ const getTokenChartData = async tokenAddress => {
     let latestPriceUSD = data[0] && data[0].priceUSD
     let latestPairDatas = data[0] && data[0].mostLiquidPairs
     let index = 1
-    while (timestamp < utcEndTime.unix() - oneDay) {
+    while (timestamp < utcEndTime.startOf('minute').unix() - oneDay) {
       const nextDay = timestamp + oneDay
       let currentDayIndex = (nextDay / oneDay).toFixed(0)
       if (!dayIndexSet.has(currentDayIndex)) {


### PR DESCRIPTION
- easy performance boosts if we round timestamp lookups to nearest minute - this will create more cached hits on the hosted subgraphs