### PR TITLE
Prevent navigation into account when removing it

### DIFF
--- a/src/components/AccountSearch/index.js
+++ b/src/components/AccountSearch/index.js
@@ -121,7 +121,12 @@ function AccountSearch({ history, small }) {
                       onClick={() => history.push('/account/' + account)}
                     >
                       <AccountLink>{account?.slice(0, 42)}</AccountLink>
-                      <Hover onClick={() => removeAccount(account)}>
+                      <Hover
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          removeAccount(account)
+                        }}
+                      >
                         <StyledIcon>
                           <X size={16} />
                         </StyledIcon>


### PR DESCRIPTION
Currently removing an account will also trigger a page navigation to that account. Here's a simple fix for that