### PR TITLE
workaround for race condition causing crash/white page on the account page

### DIFF
--- a/src/components/MiningPositionList/index.js
+++ b/src/components/MiningPositionList/index.js
@@ -135,8 +135,7 @@ function MiningPositionList({ miningPositions }) {
   }, [miningPositions])
 
   const ListItem = ({ miningPosition, index }) => {
-    if(!miningPosition.pairData)
-      return null;
+    if (!miningPosition.pairData) return null
     const pairPercentage = miningPosition.balance / miningPosition.pairData.totalSupply
     const valueUSD = miningPosition.pairData.reserveUSD
     const valueFirstPair = miningPosition.pairData.reserve0

--- a/src/components/MiningPositionList/index.js
+++ b/src/components/MiningPositionList/index.js
@@ -135,6 +135,8 @@ function MiningPositionList({ miningPositions }) {
   }, [miningPositions])
 
   const ListItem = ({ miningPosition, index }) => {
+    if(!miningPosition.pairData)
+      return null;
     const pairPercentage = miningPosition.balance / miningPosition.pairData.totalSupply
     const valueUSD = miningPosition.pairData.reserveUSD
     const valueFirstPair = miningPosition.pairData.reserve0

--- a/src/utils/returns.ts
+++ b/src/utils/returns.ts
@@ -188,7 +188,7 @@ export async function getHistoricalPairReturns(startDateTimestamp, currentPairDa
 
   const shareValues = await getShareValueOverTime(currentPairData.id, dayTimestamps)
   const shareValuesFormatted = {}
-  shareValues?.map((share) => {
+  shareValues.map((share) => {
     shareValuesFormatted[share.timestamp] = share
   })
 


### PR DESCRIPTION
Some race condition is causing a crash in MiningPositionList when pairData is not set. It has been happening for months on `https://uniswap.info/account/[address] `

This workaround seems to fix that.