### PR TITLE
enabled title link functionality for mobile/tablet users

### DIFF
--- a/src/components/Title/index.js
+++ b/src/components/Title/index.js
@@ -44,7 +44,7 @@ export default function Title() {
   const below1080 = useMedia('(max-width: 1080px)')
 
   return (
-    <TitleWrapper onClick={() => history.push('/')}>
+    <TitleWrapper>
       <Flex alignItems="center" style={{ justifyContent: 'space-between' }}>
         <RowFixed>
           <UniIcon id="link" onClick={() => history.push('/')}>


### PR DESCRIPTION
#357 and #354

Header link clicks were bubbling up to the `TitleWrapper` keeping the user on the home page.