### PR TITLE
Fix fees not calculated for first account to provide liquidity on a pair

### DIFF
--- a/src/utils/returns.ts
+++ b/src/utils/returns.ts
@@ -110,9 +110,15 @@ export function getMetricsForPositionWindow(positionT0: Position, positionT1: Po
 
   // calculate ownership at ends of window, for end of window we need original LP token balance / new total supply
   // eslint-disable-next-line eqeqeq
-  const t0Ownership = positionT0.liquidityTokenTotalSupply != 0 ? positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply : 0
+  const t0Ownership =
+    positionT0.liquidityTokenTotalSupply != 0
+      ? positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply
+      : 0
   // eslint-disable-next-line eqeqeq
-  const t1Ownership = positionT1.liquidityTokenTotalSupply != 0 ? positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply : 0
+  const t1Ownership =
+    positionT1.liquidityTokenTotalSupply != 0
+      ? positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
+      : 0
 
   // get starting amounts of token0 and token1 deposited by LP
   const token0_amount_t0 = t0Ownership * positionT0.reserve0

--- a/src/utils/returns.ts
+++ b/src/utils/returns.ts
@@ -109,8 +109,10 @@ export function getMetricsForPositionWindow(positionT0: Position, positionT1: Po
   positionT1 = formatPricesForEarlyTimestamps(positionT1)
 
   // calculate ownership at ends of window, for end of window we need original LP token balance / new total supply
-  const t0Ownership = positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply
-  const t1Ownership = positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
+  // eslint-disable-next-line eqeqeq
+  const t0Ownership = positionT0.liquidityTokenTotalSupply != 0 ? positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply : 0
+  // eslint-disable-next-line eqeqeq
+  const t1Ownership = positionT1.liquidityTokenTotalSupply != 0 ? positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply : 0
 
   // get starting amounts of token0 and token1 deposited by LP
   const token0_amount_t0 = t0Ownership * positionT0.reserve0


### PR DESCRIPTION
Issue originally raised in #363. The problem does not seem to be about how much an account provides on a pair, but rather if they were the first one to do so. In that case, the calculation of their ownership of the pool when they entered it will return a `NaN` because it will try to divide by a `liquidityTokenTotalSupply` that is equal to 0. The ownership `NaN` at t0 will then affect all subsequent calculations, including the sum of fees, hence why it is eventually not displayed. 