### PR TITLE
Added a simple return calculation per account 

### DIFF
--- a/src/pages/AccountPage.js
+++ b/src/pages/AccountPage.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { useUserTransactions, useUserPositions, useMiningPositions } from '../contexts/User'
 import TxnList from '../components/TxnList'
 import Panel from '../components/Panel'
-import { formattedNum } from '../utils'
+import { formattedNum, formattedPercent } from '../utils'
 import Row, { AutoRow, RowFixed, RowBetween } from '../components/Row'
 import { AutoColumn } from '../components/Column'
 import UserChart from '../components/UserChart'
@@ -21,6 +21,7 @@ import { BasicLink } from '../components/Link'
 import { useMedia } from 'react-use'
 import Search from '../components/Search'
 import { useSavedAccounts } from '../contexts/LocalStorage'
+import QuestionHelper from '../components/QuestionHelper'
 
 const AccountWrapper = styled.div`
   background-color: rgba(255, 255, 255, 0.2);
@@ -143,6 +144,8 @@ function AccountPage({ account }) {
         }, 0)
       : null
   }, [dynamicPositions])
+
+  const simpleReturn = (aggregateFees / (positionValue - aggregateFees)) * 100
 
   useEffect(() => {
     window.scrollTo({
@@ -284,9 +287,16 @@ function AccountPage({ account }) {
                     <div />
                   </RowBetween>
                   <RowFixed align="flex-end">
-                    <TYPE.header fontSize={'24px'} lineHeight={1} color={aggregateFees && 'green'}>
+                    <TYPE.header
+                      fontSize={'24px'}
+                      lineHeight={1}
+                      style={{ marginRight: '1rem' }}
+                      color={aggregateFees && 'green'}
+                    >
                       {aggregateFees ? formattedNum(aggregateFees, true, true) : '-'}
                     </TYPE.header>
+                    {simpleReturn ? formattedPercent(simpleReturn) : '-'}
+                    <QuestionHelper text="The simplest way to calculate your performance, this is your Fees Earned (Cumulative) divided by your Liquidity (Excluding Fees)." />
                   </RowFixed>
                 </AutoColumn>
               </AutoRow>


### PR DESCRIPTION
# Proposal
To better understand the total return of liquidity in an account/wallet, I would like to see a simple return, so I can understand the performance.

*Return Calculation = [Fees Earned (Cumulative)] / [Liquidity (Excluding Fees)]*

## Visual Changes
<img width="799" alt="Screen Shot 2021-03-11 at 6 27 04 PM" src="https://user-images.githubusercontent.com/9797920/110882870-6caece00-8297-11eb-8f34-0f1a16dd9668.png">

A tooltip may be useful to explain what the return is showing and how it is calculated.
<img width="799" alt="Screen Shot 2021-03-11 at 6 27 53 PM" src="https://user-images.githubusercontent.com/9797920/110882924-851ee880-8297-11eb-83ce-439caf7464d6.png">


