### PR TITLE
Removes censorship from Analytics

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,6 @@ import AccountLookup from './pages/AccountLookup'
 import LocalLoader from './components/LocalLoader'
 import { useLatestBlocks } from './contexts/Application'
 import GoogleAnalyticsReporter from './components/analytics/GoogleAnalyticsReporter'
-import { PAIR_BLACKLIST, TOKEN_BLACKLIST } from './constants'
 
 const AppWrapper = styled.div`
   position: relative;
@@ -128,8 +127,7 @@ function App() {
                 path="/token/:tokenAddress"
                 render={({ match }) => {
                   if (
-                    isAddress(match.params.tokenAddress.toLowerCase()) &&
-                    !Object.keys(TOKEN_BLACKLIST).includes(match.params.tokenAddress.toLowerCase())
+                    isAddress(match.params.tokenAddress.toLowerCase()) )
                   ) {
                     return (
                       <LayoutWrapper savedOpen={savedOpen} setSavedOpen={setSavedOpen}>
@@ -147,8 +145,7 @@ function App() {
                 path="/pair/:pairAddress"
                 render={({ match }) => {
                   if (
-                    isAddress(match.params.pairAddress.toLowerCase()) &&
-                    !Object.keys(PAIR_BLACKLIST).includes(match.params.pairAddress.toLowerCase())
+                    isAddress(match.params.pairAddress.toLowerCase()) )
                   ) {
                     return (
                       <LayoutWrapper savedOpen={savedOpen} setSavedOpen={setSavedOpen}>

--- a/src/components/PairList/index.js
+++ b/src/components/PairList/index.js
@@ -14,7 +14,6 @@ import DoubleTokenLogo from '../DoubleLogo'
 import FormattedName from '../FormattedName'
 import QuestionHelper from '../QuestionHelper'
 import { TYPE } from '../../Theme'
-import { PAIR_BLACKLIST } from '../../constants'
 import { AutoColumn } from '../Column'
 
 dayjs.extend(utc)
@@ -236,7 +235,7 @@ function PairList({ pairs, color, disbaleLinks, maxItems = 10, useTracked = fals
     pairs &&
     Object.keys(pairs)
       .filter(
-        (address) => !PAIR_BLACKLIST.includes(address) && (useTracked ? !!pairs[address].trackedReserveUSD : true)
+        (address) => (useTracked ? !!pairs[address].trackedReserveUSD : true)
       )
       .sort((addressA, addressB) => {
         const pairA = pairs[addressA]

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -11,7 +11,6 @@ import { useAllPairData, usePairData } from '../../contexts/PairData'
 import DoubleTokenLogo from '../DoubleLogo'
 import { useMedia } from 'react-use'
 import { useAllPairsInUniswap, useAllTokensInUniswap } from '../../contexts/GlobalData'
-import { TOKEN_BLACKLIST, PAIR_BLACKLIST } from '../../constants'
 
 import { transparentize } from 'polished'
 import { client } from '../../apollo/client'
@@ -287,9 +286,6 @@ export const Search = ({ small = false }) => {
             return 1
           })
           .filter((token) => {
-            if (TOKEN_BLACKLIST.includes(token.id)) {
-              return false
-            }
             const regexMatches = Object.keys(token).map((tokenEntryKey) => {
               const isAddress = value.slice(0, 2) === '0x'
               if (tokenEntryKey === 'id' && isAddress) {
@@ -326,9 +322,6 @@ export const Search = ({ small = false }) => {
             return 0
           })
           .filter((pair) => {
-            if (PAIR_BLACKLIST.includes(pair.id)) {
-              return false
-            }
             if (value && value.includes(' ')) {
               const pairA = value.split(' ')[0]?.toUpperCase()
               const pairB = value.split(' ')[1]?.toUpperCase()

--- a/src/components/TokenList/index.js
+++ b/src/components/TokenList/index.js
@@ -12,7 +12,6 @@ import { Divider } from '..'
 import { formattedNum, formattedPercent } from '../../utils'
 import { useMedia } from 'react-use'
 import { withRouter } from 'react-router-dom'
-import { TOKEN_BLACKLIST } from '../../constants'
 import FormattedName from '../FormattedName'
 import { TYPE } from '../../Theme'
 
@@ -140,15 +139,7 @@ function TopTokenList({ tokens, itemMax = 10, useTracked = false }) {
   }, [tokens])
 
   const formattedTokens = useMemo(() => {
-    return (
-      tokens &&
-      Object.keys(tokens)
-        .filter((key) => {
-          return !TOKEN_BLACKLIST.includes(key)
-        })
-        .map((key) => tokens[key])
-    )
-  }, [tokens])
+    return (tokens)}, [tokens])
 
   useEffect(() => {
     if (tokens && formattedTokens) {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -17,31 +17,6 @@ export const SUPPORTED_LIST_URLS__NO_ENS = [
   'https://www.coingecko.com/tokens_list/uniswap/defi_100/v_0_0_0.json',
 ]
 
-// hide from overview list
-export const TOKEN_BLACKLIST = [
-  '0x495c7f3a713870f68f8b418b355c085dfdc412c3',
-  '0xc3761eb917cd790b30dad99f6cc5b4ff93c4f9ea',
-  '0xe31debd7abff90b06bca21010dd860d8701fd901',
-  '0xfc989fbb6b3024de5ca0144dc23c18a063942ac1',
-  '0xf4eda77f0b455a12f3eb44f8653835f377e36b76',
-  '0x93b2fff814fcaeffb01406e80b4ecd89ca6a021b',
-
-  // rebass tokens
-  '0x9ea3b5b4ec044b70375236a281986106457b20ef',
-  '0x05934eba98486693aaec2d00b0e9ce918e37dc3f',
-  '0x3d7e683fc9c86b4d653c9e47ca12517440fad14e',
-  '0xfae9c647ad7d89e738aba720acf09af93dc535f7',
-  '0x7296368fe9bcb25d3ecc19af13655b907818cc09',
-]
-
-// pair blacklist
-export const PAIR_BLACKLIST = [
-  '0xb6a741f37d6e455ebcc9f17e2c16d0586c3f57a5',
-  '0x97cb8cbe91227ba87fc21aaf52c4212d245da3f8',
-  '0x1acba73121d5f63d8ea40bdc64edb594bd88ed09',
-  '0x7d7e813082ef6c143277c71786e5be626ec77b20',
-]
-
 // warnings to display if page contains info about blocked token
 export const BLOCKED_WARNINGS = {
   '0xf4eda77f0b455a12f3eb44f8653835f377e36b76':

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -37,7 +37,6 @@ import { Bookmark, PlusCircle, AlertCircle } from 'react-feather'
 import FormattedName from '../components/FormattedName'
 import { useListedTokens } from '../contexts/Application'
 import HoverText from '../components/HoverText'
-import { UNTRACKED_COPY, PAIR_BLACKLIST, BLOCKED_WARNINGS } from '../constants'
 
 const DashboardWrapper = styled.div`
   width: 100%;
@@ -194,23 +193,6 @@ function PairPage({ pairAddress, history }) {
   const [savedPairs, addPair] = useSavedPairs()
 
   const listedTokens = useListedTokens()
-
-  if (PAIR_BLACKLIST.includes(pairAddress)) {
-    return (
-      <BlockedWrapper>
-        <BlockedMessageWrapper>
-          <AutoColumn gap="1rem" justify="center">
-            <TYPE.light style={{ textAlign: 'center' }}>
-              {BLOCKED_WARNINGS[pairAddress] ?? `This pair is not supported.`}
-            </TYPE.light>
-            <Link external={true} href={'https://etherscan.io/address/' + pairAddress}>{`More about ${shortenAddress(
-              pairAddress
-            )}`}</Link>
-          </AutoColumn>
-        </BlockedMessageWrapper>
-      </BlockedWrapper>
-    )
-  }
 
   return (
     <PageWrapper>

--- a/src/pages/TokenPage.js
+++ b/src/pages/TokenPage.js
@@ -31,7 +31,6 @@ import { PlusCircle, Bookmark, AlertCircle } from 'react-feather'
 import FormattedName from '../components/FormattedName'
 import { useListedTokens } from '../contexts/Application'
 import HoverText from '../components/HoverText'
-import { UNTRACKED_COPY, TOKEN_BLACKLIST, BLOCKED_WARNINGS } from '../constants'
 import QuestionHelper from '../components/QuestionHelper'
 import Checkbox from '../components/Checkbox'
 import { shortenAddress } from '../utils'
@@ -170,23 +169,6 @@ function TokenPage({ address, history }) {
   }, [])
 
   const [useTracked, setUseTracked] = useState(true)
-
-  if (TOKEN_BLACKLIST.includes(address)) {
-    return (
-      <BlockedWrapper>
-        <BlockedMessageWrapper>
-          <AutoColumn gap="1rem" justify="center">
-            <TYPE.light style={{ textAlign: 'center' }}>
-              {BLOCKED_WARNINGS[address] ?? `This token is not supported.`}
-            </TYPE.light>
-            <Link external={true} href={'https://etherscan.io/address/' + address}>{`More about ${shortenAddress(
-              address
-            )}`}</Link>
-          </AutoColumn>
-        </BlockedMessageWrapper>
-      </BlockedWrapper>
-    )
-  }
 
   return (
     <PageWrapper>


### PR DESCRIPTION
Removed all token and pair blacklists from Uniswap analytics. 

Ethereum is meant to be censorship resistant money, where people can go to freely interact and trade with each other without fear of being kicked out of the financial system we are building by governments, banks, corporations, etc. When applications are built on top of Ethereum, they should strive to uphold that ethos and they should not be quick to fold at the first time of any pushback.

By removing censoring code, we can start working together toward a brighter future where humans have the right to freedom of speech/expression/association (including financial expression and trade) and these freedoms aren't wantonly removed by governments and businesses.
