### PR TITLE
fixed typo in total fees accrued calculator

### DIFF
--- a/src/utils/returns.ts
+++ b/src/utils/returns.ts
@@ -110,7 +110,7 @@ export function getMetricsForPositionWindow(positionT0: Position, positionT1: Po
 
   // calculate ownership at ends of window, for end of window we need original LP token balance / new total supply
   const t0Ownership = positionT0.liquidityTokenBalance / positionT0.liquidityTokenTotalSupply
-  const t1Ownership = positionT0.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
+  const t1Ownership = positionT1.liquidityTokenBalance / positionT1.liquidityTokenTotalSupply
 
   // get starting amounts of token0 and token1 deposited by LP
   const token0_amount_t0 = t0Ownership * positionT0.reserve0


### PR DESCRIPTION
I believe that there is a typo in this code, where positionT0 (state of the pool at time t0) is used instead of positionT1 (state at T1).

If someone could please explain how this calculates the fees and/or give me a resource that explains it, it would be great. The calculations done don't seem to make any sense to me, and I feel like either something is going wrong or I have a major flaw in my understanding. Any help would be greatly appreciated.