### PR TITLE
fix: combined typo

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -126,7 +126,7 @@ function App() {
       <AppWrapper>
         <BannerWrapper>
           <UrlBanner>
-            {`Explore the new combinved V2 and V3 analytics at `}
+            {`Explore the new combined V2 and V3 analytics at `}
             <Link color="white" external href={'https://app.uniswap.org/explore'}>
               <Decorator>app.uniswap.org</Decorator>
             </Link>{' '}


### PR DESCRIPTION
There is a typo in the banner `combinved`

<img width="477" alt="Screenshot 2024-04-14 at 01 08 33" src="https://github.com/Uniswap/info/assets/81092286/9f320f00-1312-40e5-81c6-e2f0af605a3f">
